### PR TITLE
Edits to popup formatting, marker style

### DIFF
--- a/IrmaShiny.R
+++ b/IrmaShiny.R
@@ -21,6 +21,9 @@ Irma_Tweets <- read_csv("~/Irma_Tweets.csv")
 #jitter coordinates for IRMA tweets to avoid overlap (can click on overlapping tweets if zoomed in enough)
 Irma_Tweets[3:4] <- jitterDupCoords(Irma_Tweets[3:4], max = 0.001, min = 0.0001, fix.one = TRUE, which.fix = "first")
 
+#order by image score so higher scores are on top
+Irma_Tweets <- Irma_Tweets[order(Irma_Tweets$imageScore),]
+
 #load Irma tracks
 IrmaTrack <- read_csv("~/IrmaTrack.csv")
 IrmaTrack$datetime <-parse_datetime(IrmaTrack$datetime,"%Y%m%d")
@@ -53,8 +56,8 @@ ui <- bootstrapPage(
                             value = range(Irma_Tweets$userScore), step = 0.1),
                 sliderInput("rangefour", "GIS Score", 0,1,
                             value = range(Irma_Tweets$gisScore), step = 0.1),
-                selectInput("colors", "Color Scheme",
-                            rownames(subset(brewer.pal.info, category %in% c("seq", "div")))),
+                #selectInput("colors", "Color Scheme",
+                            #rownames(subset(brewer.pal.info, category %in% c("seq", "div")))),
                 checkboxInput("legend", "Show legend", TRUE)
   )
 )
@@ -71,9 +74,9 @@ server <- function(input, output, session) {
                 ,]
   })
   
-  # Reactive expression for the slider color, with colors coresponding to image score. 
+  # Reactive expression for the slider color, with colors corresponding to image score. 
   colorpal <- reactive({
-    colorNumeric(input$colors, Irma_Tweets$imageScore)
+    colorNumeric("viridis", Irma_Tweets$imageScore)
   })
   
   output$map <- renderLeaflet({

--- a/IrmaShiny.R
+++ b/IrmaShiny.R
@@ -12,9 +12,14 @@ library(tidyverse)
 library(mapview)
 library(shiny)
 library(RColorBrewer)
+#add geoR for jitterDupCoords
+library(geoR)
 
 #import the IRMA tweets (n.b., after the hydration step)
 Irma_Tweets <- read_csv("~/Irma_Tweets.csv")
+
+#jitter coordinates for IRMA tweets to avoid overlap (can click on overlapping tweets if zoomed in enough)
+Irma_Tweets[3:4] <- jitterDupCoords(Irma_Tweets[3:4], max = 0.001, min = 0.0001, fix.one = TRUE, which.fix = "first")
 
 #load Irma tracks
 IrmaTrack <- read_csv("~/IrmaTrack.csv")
@@ -37,7 +42,7 @@ URL  = paste0("'","<a"," href", "=", Irma_Tweets$image_url , " target = '_blank'
 # S3) User Score
 # S4) GIS Score
 ui <- bootstrapPage(
-  tags$style(type = "text/css", "html, body {width:100%;height:100%}"),
+  tags$style(type = "text/css", "html, body {width:100%;height:100%} img {display:block;margin-left:auto;margin-right:auto;width:80%;}"),
   leafletOutput("map", width = "100%", height = "100%"),
   absolutePanel(top = 10, right = 10,
                 sliderInput("range", "Image Score", 0,1,
@@ -72,9 +77,9 @@ server <- function(input, output, session) {
   })
   
   output$map <- renderLeaflet({
-    # Make the leaflet map. Pull the basemap from OSM. 
+    # Make the leaflet map. Pull the basemap. Changed to Stamen TonerLite for simplicity, but I wish it had color :( -JK 
     leaflet(Irma_Tweets) %>% 
-      addProviderTiles(providers$OpenStreetMap) %>%
+      addProviderTiles(providers$Stamen.TonerLite) %>%
       fitBounds(~min(longitude), ~min(latitude), ~max(longitude), ~max(latitude)) %>% 
       addPolylines(data = IrmaTrack, lng = ~c(-log), lat = ~lat)
   })
@@ -84,10 +89,11 @@ server <- function(input, output, session) {
     pal <- colorpal()
     leafletProxy("map", data = filteredData()) %>%
       clearShapes() %>%
-      addCircles(
-        stroke = TRUE, radius = 2000, weight = 1, color = "#777777",
-        fillColor = ~pal(imageScore), fillOpacity = 0.7,
-        popup = ~paste(text, "<img height='200' src = ", image_url, ">")
+      addCircleMarkers(
+        stroke = FALSE, radius = 7, 
+        #weight = 1, color = "#777777",
+        fillColor = ~pal(imageScore), fillOpacity = 0.6,
+        popup = ~paste("<b>Tweet Text: </b>",text, "<br><br><img width ='80%' src = ", image_url, " alt = 'Tweet Image' align = 'middle'>")
       )
   })
   


### PR DESCRIPTION
- Added geoR to library for jitterDupCoords to jitter overlapping coordinates for clickability when zoomed in
- Jittered coordinates
- Added img to CSS style to center images in popups
- Changed basemap tiles to Stamen Toner Lite to reduce visual noise
- Changed markers from Circles (fixed radius in meters) to CircleMarkers (fixed # pixels)
- Removed border of circle markers to make it pretty :)
- Changed popups for formatting and to center images, fixed image overspill